### PR TITLE
use old index mapping for tmp index during reingestion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - run: pip install black
+      with: 
+        python-version: '3.10'
+        cache: 'pip'
+    - run: pip install -Ur requirements.txt
     - run: black --check .
 
   flake8:
@@ -16,5 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - run: pip install flake8
+      with: 
+        python-version: '3.10'
+        cache: 'pip'
+    - run: pip install -Ur requirements.txt
     - run: flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     
     - run: |
           pip install -r requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.12']
+        python-version: ['3.10', '3.12']
 
     services:
       elastic:

--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -1067,10 +1067,13 @@ class Elastic(DataLayer):
 
         # create new index
         new_index = generate_index_name(alias)
-        es.indices.create(index=new_index, body={
-            "settings": {"index": settings["settings"]} if settings else {},
-            "mappings": fix_mapping(mappings) if mappings else {},
-        })
+        es.indices.create(
+            index=new_index,
+            body={
+                "settings": {"index": settings["settings"]} if settings else {},
+                "mappings": fix_mapping(mappings) if mappings else {},
+            },
+        )
 
         print("NEW INDEX", new_index)
 
@@ -1110,10 +1113,16 @@ class Elastic(DataLayer):
 
         # tmp index will be used for new items arriving during reindex
         tmp_index = f"{old_index}-tmp"
-        es.indices.rollover(alias=alias, new_index=tmp_index, body={
-            "mappings": old_mappings[old_index]["mappings"] if old_mappings else mappings,
-            "settings": {"index": settings["settings"]} if settings else None,
-        })
+        es.indices.rollover(
+            alias=alias,
+            new_index=tmp_index,
+            body={
+                "mappings": (
+                    old_mappings[old_index]["mappings"] if old_mappings else mappings
+                ),
+                "settings": {"index": settings["settings"]} if settings else None,
+            },
+        )
 
         print("TMP INDEX", tmp_index)
 

--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -1048,13 +1048,14 @@ class Elastic(DataLayer):
         es = self.elastic(resource)
         alias = self._resource_index(resource)
         settings = self._resource_config(resource, "SETTINGS")
-        mapping = self._resource_mapping(resource)
+        mappings = self._resource_mapping(resource)
 
-        old_index = None
+        old_index = old_mappings = None
         try:
             indexes = es.indices.get_alias(name=alias)
             for index, aliases in indexes.items():
                 old_index = index
+                old_mappings = es.indices.get_mapping(index=index)
                 specs = aliases["aliases"][alias]
                 if specs and specs["is_write_index"]:
                     break
@@ -1066,8 +1067,10 @@ class Elastic(DataLayer):
 
         # create new index
         new_index = generate_index_name(alias)
-        self._create_index(es, new_index, settings)
-        self._put_mapping(es, new_index, mapping)
+        es.indices.create(index=new_index, body={
+            "settings": {"index": settings["settings"]} if settings else {},
+            "mappings": fix_mapping(mappings) if mappings else {},
+        })
 
         print("NEW INDEX", new_index)
 
@@ -1107,31 +1110,12 @@ class Elastic(DataLayer):
 
         # tmp index will be used for new items arriving during reindex
         tmp_index = f"{old_index}-tmp"
-        self._create_index(es, tmp_index, settings)
-        self._put_mapping(es, tmp_index, mapping)
-        print("TMP INDEX", tmp_index)
+        es.indices.rollover(alias=alias, new_index=tmp_index, body={
+            "mappings": old_mappings[old_index]["mappings"] if old_mappings else mappings,
+            "settings": {"index": settings["settings"]} if settings else None,
+        })
 
-        # add tmp index as writable
-        es.indices.update_aliases(
-            body={
-                "actions": [
-                    {
-                        "add": {  # add tmp index as write index
-                            "index": tmp_index,
-                            "alias": alias,
-                            "is_write_index": True,
-                        },
-                    },
-                    {
-                        "add": {  # make sure the old index is not write index
-                            "index": old_index,
-                            "alias": alias,
-                            "is_write_index": False,
-                        },
-                    },
-                ],
-            }
-        )
+        print("TMP INDEX", tmp_index)
 
         _background_reindex(
             es, old_index, new_index, requests_per_second=requests_per_second

--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -1120,7 +1120,7 @@ class Elastic(DataLayer):
                 "mappings": (
                     old_mappings[old_index]["mappings"] if old_mappings else mappings
                 ),
-                "settings": {"index": settings["settings"]} if settings else None,
+                "settings": {"index": settings["settings"]} if settings else {},
             },
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-pytest
+black==24.10.0
 eve>1.1,<2.2
+flake8==7.1.1
+pytest==8.3.4

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     url="https://github.com/petrjasek/eve-elastic",
     packages=["eve_elastic"],
     test_suite="test.test_elastic",
-    tests_require=["nose", "flake8"],
     install_requires=[
         "arrow>=0.4.2",
         "ciso8601>=1.0.2,<3",

--- a/test/test_elastic.py
+++ b/test/test_elastic.py
@@ -918,6 +918,25 @@ class TestElastic(TestCase):
 
             assert es.indices.exists_alias(alias)
 
+    def test_reindex(self):
+        ITEMS = "items"
+        with self.app.app_context():
+            elastic = self.app.data
+            elastic.insert(ITEMS, [{"uri": "foo", "name": "item"}])
+            old_index = elastic.get_index(ITEMS)
+            elastic.reindex(ITEMS)
+            new_index = elastic.get_index(ITEMS)
+            assert old_index != new_index
+            docs = elastic.search(
+                {
+                    "query": {
+                        "match_all": {},
+                    },
+                },
+                ITEMS,
+            )
+            self.assertEqual(1, docs.count())
+
 
 class TestElasticSearchWithSettings(TestCase):
     resource = "items"


### PR DESCRIPTION
it uses both indices for searching during reingestion and if there is a mapping change in a field used in aggregation/query it fails.
plus use rollover for alias handling