### PR TITLE
[SDESK-7574] Changes for async client in superdesk

### DIFF
--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -581,8 +581,7 @@ class Elastic(DataLayer):
             ]
         }
 
-    def find(self, resource, req, sub_resource_lookup, **kwargs):
-        """Find documents for resource."""
+    def get_find_kwargs(self, resource, req, sub_resource_lookup) -> dict:
         args = getattr(req, "args", request.args if request else {}) or {}
         source_config = app.config["DOMAIN"][resource]["datasource"]
 
@@ -672,10 +671,18 @@ class Elastic(DataLayer):
         default_params = self._get_default_search_params()
         if args is not None:
             default_params.update(args)
-        args = default_params
+
+        return dict(
+            **default_params,
+            body=fix_query(query),
+        )
+
+    def find(self, resource, req, sub_resource_lookup, **kwargs):
+        """Find documents for resource."""
+        search_args = self.get_find_kwargs(resource, req, sub_resource_lookup)
 
         try:
-            hits = self.elastic(resource).search(body=fix_query(query), **args)
+            hits = self.elastic(resource).search(**search_args)
         except elasticsearch.exceptions.RequestError as e:
             if e.status_code == 400 and "No mapping found for" in e.error:
                 hits = {}
@@ -742,6 +749,16 @@ class Elastic(DataLayer):
             )[2]
             return ",".join([key for key, val in projection.items() if val])
 
+    def get_find_one_kwargs(self, resource, **lookup) -> dict:
+        args = self._es_args(resource)
+        filters = [{"term": {key: val}} for key, val in lookup.items()]
+        query = {"query": {"bool": {"must": filters}}}
+        args["size"] = 1
+        return dict(
+            **args,
+            body=fix_query(query),
+        )
+
     def find_one(self, resource, req, **lookup):
         """Find single document, if there is _id in lookup use that, otherwise filter."""
         if config.ID_FIELD in lookup:
@@ -750,20 +767,14 @@ class Elastic(DataLayer):
                 _id=lookup[config.ID_FIELD],
                 parent=lookup.get("parent"),
             )
-        else:
-            args = self._es_args(resource)
-            filters = [{"term": {key: val}} for key, val in lookup.items()]
-            query = {"query": {"bool": {"must": filters}}}
 
-            try:
-                args["size"] = 1
-                hits = self.elastic(resource).search(
-                    body=fix_query(query), **args
-                )
-                docs = self._parse_hits(hits, resource)
-                return docs.first()
-            except elasticsearch.NotFoundError:
-                return
+        search_args = self.get_find_one_kwargs(resource, **lookup)
+        try:
+            hits = self.elastic(resource).search(**search_args)
+            docs = self._parse_hits(hits, resource)
+            return docs.first()
+        except elasticsearch.NotFoundError:
+            return
 
     def _find_by_id(self, resource, _id, parent=None):
         """Find the document by Id. If parent is not provided then on
@@ -859,7 +870,7 @@ class Elastic(DataLayer):
         self._refresh_resource_index(resource)
         return res
 
-    def update(self, resource, id_, updates):
+    def update(self, resource, id_, updates, original=None):
         """Update document in index."""
         args = self._es_args(resource, refresh=True)
         if self._get_retry_on_conflict():
@@ -867,7 +878,7 @@ class Elastic(DataLayer):
         doc = self._prepare_for_storage(resource, updates, args)
         return self.elastic(resource).update(id=id_, body={"doc": doc}, **args)
 
-    def replace(self, resource, id_, document):
+    def replace(self, resource, id_, document, original=None):
         """Replace document in index."""
         args = self._es_args(resource, refresh=True)
         doc = self._prepare_for_storage(resource, document, args)
@@ -939,7 +950,7 @@ class Elastic(DataLayer):
         es.indices.put_settings(index=index, body=settings)
         es.indices.open(index=index)
 
-    def _parse_hits(self, hits, resource):
+    def get_hits_docs(self, hits, resource) -> list[dict]:
         """Parse hits response into documents."""
         datasource = self.get_datasource(resource)
         schema = {}
@@ -949,7 +960,11 @@ class Elastic(DataLayer):
         docs = []
         for hit in hits.get("hits", {}).get("hits", []):
             docs.append(format_doc(hit, schema, dates))
-        return ElasticCursor(hits, docs)
+        return docs
+
+    def _parse_hits(self, hits, resource):
+        """Parse hits response into documents."""
+        return ElasticCursor(hits, self.get_hits_docs(hits, resource))
 
     def _es_args(self, resource, refresh=None, source_projections=None):
         """Get index and doctype args."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-eve>1.1,<2.3
+eve @ git+https://github.com/superdesk/eve@async
+motor>=3.4.0,<4.0
 ruff==0.9.2
 pytest==8.3.4

--- a/test/test_elastic.py
+++ b/test/test_elastic.py
@@ -6,10 +6,10 @@ import pytest
 import logging
 import elasticsearch
 
-from unittest import TestCase, skip
+from unittest import IsolatedAsyncioTestCase, skip
 from datetime import datetime
 from copy import deepcopy
-from flask import json
+from quart import json
 from eve.utils import config, ParsedRequest, parse_request
 from eve_elastic.elastic import parse_date, Elastic, get_es, generate_index_name
 
@@ -148,8 +148,8 @@ INDEX = "elastic_tests"
 DOC_TYPE = "items"
 
 
-class TestElastic(TestCase):
-    def setUp(self):
+class TestElastic(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
         settings = {"DOMAIN": DOMAIN}
         settings["ELASTICSEARCH_URL"] = "http://localhost:9200"
         settings["ELASTICSEARCH_INDEX"] = INDEX
@@ -158,7 +158,7 @@ class TestElastic(TestCase):
         settings["DEBUG"] = True
         self.es = elasticsearch.Elasticsearch([settings["ELASTICSEARCH_URL"]])
         self.app = eve.Eve(settings=settings, data=Elastic)
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.drop_index()
             self.app.data.init_index()
 
@@ -174,8 +174,8 @@ class TestElastic(TestCase):
     def test_generate_index_name(self):
         self.assertNotEqual(generate_index_name("a"), generate_index_name("a"))
 
-    def test_get_mapping(self):
-        with self.app.app_context():
+    async def test_get_mapping(self):
+        async with self.app.app_context():
             mapping = self.app.data.get_mapping("items")
 
         items_mapping = mapping["mappings"]["properties"]
@@ -201,8 +201,8 @@ class TestElastic(TestCase):
         self.assertIn("created", place_mapping["properties"])
         self.assertEqual("date", place_mapping["properties"]["created"]["type"])
 
-    def test_dates_are_parsed_on_fetch(self):
-        with self.app.app_context():
+    async def test_dates_are_parsed_on_fetch(self):
+        async with self.app.app_context():
             ids = self.app.data.insert(
                 "items",
                 [{"uri": "test", "firstcreated": "2012-10-10T11:12:13+0000"}],
@@ -218,8 +218,8 @@ class TestElastic(TestCase):
             self.assertIsInstance(item["firstcreated"], datetime)
             self.assertIsInstance(item["published"], datetime)
 
-    def test_bulk_insert(self):
-        with self.app.app_context():
+    async def test_bulk_insert(self):
+        async with self.app.app_context():
             (count, _errors) = self.app.data.bulk_insert(
                 "items_with_description",
                 [
@@ -247,8 +247,8 @@ class TestElastic(TestCase):
             self.assertEqual(3, count)
             self.assertEqual(0, len(_errors))
 
-    def test_query_filter_with_filter_dsl_and_schema_filter(self):
-        with self.app.app_context():
+    async def test_query_filter_with_filter_dsl_and_schema_filter(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [
@@ -273,7 +273,7 @@ class TestElastic(TestCase):
 
         query_filter = {"term": {"name": "foo"}}
 
-        with self.app.app_context():
+        async with self.app.app_context():
             req = ParsedRequest()
             req.args = {"filter": json.dumps(query_filter)}
             cursor, count = self.app.data.find(
@@ -281,7 +281,7 @@ class TestElastic(TestCase):
             )
             self.assertEqual(1, count)
 
-        with self.app.app_context():
+        async with self.app.app_context():
             req = ParsedRequest()
             req.args = {"q": "bar", "filter": json.dumps(query_filter)}
             cursor, count = self.app.data.find(
@@ -289,9 +289,9 @@ class TestElastic(TestCase):
             )
             self.assertEqual(0, count)
 
-    def test_find_one_by_id(self):
+    async def test_find_one_by_id(self):
         """elastic 1.0+ is using 'found' property instead of 'exists'"""
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.insert(
                 "items", [{"uri": "test", config.ID_FIELD: "testid"}]
             )
@@ -300,8 +300,8 @@ class TestElastic(TestCase):
             )
             self.assertEqual("testid", item[config.ID_FIELD])
 
-    def test_find_one_multiple_criteria(self):
-        with self.app.app_context():
+    async def test_find_one_multiple_criteria(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items",
                 [{"uri": "test", "name": "foo", config.ID_FIELD: "testid"}],
@@ -311,17 +311,17 @@ class TestElastic(TestCase):
             )
             self.assertEqual("testid", item[config.ID_FIELD])
 
-    def test_formating_fields(self):
+    async def test_formating_fields(self):
         """when using elastic 1.0+ it puts all requested fields values into a list
         so instead of {"name": "test"} it returns {"name": ["test"]}"""
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.insert("items", [{"uri": "test", "name": "test"}])
             item = self.app.data.find_one("items", req=None, uri="test")
             self.assertEqual("test", item["name"])
 
-    def test_search_via_source_param(self):
+    async def test_search_via_source_param(self):
         query = {"query": {"term": {"uri": "foo"}}}
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.insert("items", [{"uri": "foo", "name": "foo"}])
             self.app.data.insert("items", [{"uri": "bar", "name": "bar"}])
             req = ParsedRequest()
@@ -329,9 +329,9 @@ class TestElastic(TestCase):
             res, count = self.app.data.find("items", req, None)
             self.assertEqual(1, res.count())
 
-    def test_search_via_source_param_and_schema_filter(self):
+    async def test_search_via_source_param_and_schema_filter(self):
         query = {"query": {"term": {"uri": "foo"}}}
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [{"uri": "foo", "description": "test", "name": "foo"}],
@@ -344,9 +344,9 @@ class TestElastic(TestCase):
             res, count = self.app.data.find("items_with_description", req, None)
             self.assertEqual(1, res.count())
 
-    def test_search_via_source_param_and_with_highlight(self):
+    async def test_search_via_source_param_and_with_highlight(self):
         query = {"query": {"query_string": {"query": "foo"}}}
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [{"uri": "foo", "description": "This is foo", "name": "foo"}],
@@ -369,8 +369,8 @@ class TestElastic(TestCase):
                 'This is <span class="es-highlight">foo</span>',
             )
 
-    def test_search_with_highlight_without_query_string_query(self):
-        with self.app.app_context():
+    async def test_search_with_highlight_without_query_string_query(self):
+        async with self.app.app_context():
             req = ParsedRequest()
             req.args = {
                 "source": json.dumps({"query": {"term": {"name": "foo"}}}),
@@ -379,9 +379,9 @@ class TestElastic(TestCase):
             res, count = self.app.data.find("items_with_description", req, None)
             self.assertEqual(0, res.count())
 
-    def test_search_via_source_param_and_without_highlight(self):
+    async def test_search_via_source_param_and_without_highlight(self):
         query = {"query": {"query_string": {"query": "foo"}}}
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [{"uri": "foo", "description": "This is foo", "name": "foo"}],
@@ -396,9 +396,9 @@ class TestElastic(TestCase):
             es_highlight = res[0].get("es_highlight")
             self.assertIsNone(es_highlight)
 
-    def test_search_via_source_param_and_with_source_projection(self):
+    async def test_search_via_source_param_and_with_source_projection(self):
         query = {"query": {"query_string": {"query": "foo"}}}
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [{"uri": "foo", "description": "This is foo", "name": "foo"}],
@@ -417,8 +417,8 @@ class TestElastic(TestCase):
             self.assertTrue("name" in res.docs[0])
             self.assertEqual("items_with_description", res.docs[0]["_type"])
 
-    def test_should_aggregate(self):
-        with self.app.app_context():
+    async def test_should_aggregate(self):
+        async with self.app.app_context():
             self.app.config["ELASTICSEARCH_AUTO_AGGREGATIONS"] = False
             req = ParsedRequest()
             req.args = {"aggregations": 1}
@@ -426,8 +426,8 @@ class TestElastic(TestCase):
             req.args = {"aggregations": "0"}
             self.assertFalse(self.app.data.should_aggregate(req))
 
-    def test_should_project(self):
-        with self.app.app_context():
+    async def test_should_project(self):
+        async with self.app.app_context():
             req = ParsedRequest()
             req.args = {
                 "projections": json.dumps(
@@ -446,8 +446,8 @@ class TestElastic(TestCase):
             req.args = {}
             self.assertFalse(self.app.data.should_project(req))
 
-    def test_get_projected_fields(self):
-        with self.app.app_context():
+    async def test_get_projected_fields(self):
+        async with self.app.app_context():
             req = ParsedRequest()
             req.args = {
                 "projections": json.dumps(
@@ -466,8 +466,8 @@ class TestElastic(TestCase):
                 "priority,urgency,word_count,slugline,highlights,_resource",
             )
 
-    def test_eve_projection(self):
-        with self.app.app_context():
+    async def test_eve_projection(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items",
                 [
@@ -498,42 +498,42 @@ class TestElastic(TestCase):
             self.assertIn("_updated", fields)
             self.assertNotIn("firstcreated", fields)
 
-    def test_should_highlight(self):
-        with self.app.app_context():
+    async def test_should_highlight(self):
+        async with self.app.app_context():
             req = ParsedRequest()
             req.args = {"es_highlight": 1}
             self.assertTrue(self.app.data.should_highlight(req))
             req.args = {"es_highlight": "0"}
             self.assertFalse(self.app.data.should_highlight(req))
 
-    def test_mapping_is_there_after_delete(self):
-        with self.app.app_context():
+    async def test_mapping_is_there_after_delete(self):
+        async with self.app.app_context():
             mapping = self.app.data.get_mapping(DOC_TYPE)
             self.app.data.remove("items")
             self.assertEqual(mapping, self.app.data.get_mapping(DOC_TYPE))
 
-    def test_find_one_raw(self):
-        with self.app.app_context():
+    async def test_find_one_raw(self):
+        async with self.app.app_context():
             ids = self.app.data.insert("items", [{"uri": "foo", "name": "foo"}])
             item = self.app.data.find_one_raw("items", ids[0])
             self.assertEqual(item["name"], "foo")
 
-    def test_is_empty(self):
-        with self.app.app_context():
+    async def test_is_empty(self):
+        async with self.app.app_context():
             self.assertTrue(self.app.data.is_empty("items"))
             self.app.data.insert("items", [{"uri": "foo"}])
             self.assertFalse(self.app.data.is_empty("items"))
 
-    def test_replace(self):
-        with self.app.app_context():
+    async def test_replace(self):
+        async with self.app.app_context():
             res = self.app.data.insert("items", [{"uri": "foo"}])
             self.assertEqual(1, len(res))
             new_item = {"uri": "bar"}
             res = self.app.data.replace("items", res.pop(), new_item)
             self.assertEqual(2, res["_version"])
 
-    def test_sub_resource_lookup(self):
-        with self.app.app_context():
+    async def test_sub_resource_lookup(self):
+        async with self.app.app_context():
             self.app.data.insert("items", [{"uri": "foo", "name": "foo"}])
             req = ParsedRequest()
             req.args = {}
@@ -546,8 +546,8 @@ class TestElastic(TestCase):
             )
             self.assertEqual(1, count)
 
-    def test_sub_resource_lookup_with_schema_filter(self):
-        with self.app.app_context():
+    async def test_sub_resource_lookup_with_schema_filter(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [{"uri": "foo", "description": "test", "name": "foo"}],
@@ -563,8 +563,8 @@ class TestElastic(TestCase):
             )
             self.assertEqual(0, count)
 
-    def test_resource_filter(self):
-        with self.app.app_context():
+    async def test_resource_filter(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [{"uri": "foo", "description": "test"}, {"uri": "bar"}],
@@ -579,24 +579,24 @@ class TestElastic(TestCase):
             )
             self.assertEqual(0, count)
 
-    def test_where_filter(self):
-        with self.app.app_context():
+    async def test_where_filter(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items",
                 [{"uri": "foo", "name": "foo"}, {"uri": "bar", "name": "bar"}],
             )
 
-        with self.app.test_client() as c:
-            response = c.get('items?where={"name":"foo"}')
-            data = json.loads(response.data)
+        async with self.app.test_client() as c:
+            response = await c.get('items?where={"name":"foo"}')
+            data = json.loads(await response.get_data())
             self.assertEqual(1, len(data["_items"]))
 
-            response = c.get('items?where=name=="foo"')
-            data = json.loads(response.data)
+            response = await c.get('items?where=name=="foo"')
+            data = json.loads(await response.get_data())
             self.assertEqual(1, len(data["_items"]))
 
-    def test_update(self):
-        with self.app.app_context():
+    async def test_update(self):
+        async with self.app.app_context():
             ids = self.app.data.insert("items", [{"uri": "foo"}])
             self.app.data.update(
                 "items", ids[0], {"uri": "bar", "_id": ids[0], "_type": "items"}
@@ -606,8 +606,8 @@ class TestElastic(TestCase):
                 "bar",
             )
 
-    def test_remove_by_id(self):
-        with self.app.app_context():
+    async def test_remove_by_id(self):
+        async with self.app.app_context():
             self.ids = self.app.data.insert(
                 "items", [{"uri": "foo"}, {"uri": "bar"}]
             )
@@ -617,21 +617,21 @@ class TestElastic(TestCase):
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(1, count)
 
-    def test_remove_non_existing_item(self):
-        with self.app.app_context():
+    async def test_remove_non_existing_item(self):
+        async with self.app.app_context():
             self.assertEqual(
                 self.app.data.remove("items", {"_id": "notfound"}), None
             )
 
-    def test_it_can_use_configured_url(self):
+    async def test_it_can_use_configured_url(self):
         with pytest.raises(elasticsearch.exceptions.ConnectionError):
-            with self.app.app_context():
+            async with self.app.app_context():
                 self.app.config["ELASTICSEARCH_URL"] = "http://localhost:9292"
                 elastic = Elastic(self.app)
                 elastic.init_index()
 
-    def test_resource_aggregates(self):
-        with self.app.app_context():
+    async def test_resource_aggregates(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [{"uri": "foo1", "description": "test", "name": "foo"}],
@@ -664,8 +664,8 @@ class TestElastic(TestCase):
                 3, response["_aggregations"]["type"]["buckets"][0]["doc_count"]
             )
 
-    def test_resource_aggregates_no_auto(self):
-        with self.app.app_context():
+    async def test_resource_aggregates_no_auto(self):
+        async with self.app.app_context():
             self.app.data.insert("items_with_description", [{"uri": "foo"}])
             self.app.config["ELASTICSEARCH_AUTO_AGGREGATIONS"] = False
             req = ParsedRequest()
@@ -684,8 +684,8 @@ class TestElastic(TestCase):
             cursor.extra(response)
             self.assertIn("_aggregations", response)
 
-    def test_put(self):
-        with self.app.app_context():
+    async def test_put(self):
+        async with self.app.app_context():
             self.app.data.replace(
                 "items", "newid", {"uri": "foo", "_id": "newid", "_type": "x"}
             )
@@ -693,8 +693,8 @@ class TestElastic(TestCase):
                 "foo", self.app.data.find_one("items", None, _id="newid")["uri"]
             )
 
-    def test_args_filter(self):
-        with self.app.app_context():
+    async def test_args_filter(self):
+        async with self.app.app_context():
             self.app.data.insert("items", [{"uri": "foo"}, {"uri": "bar"}])
             req = ParsedRequest()
             req.args = {}
@@ -702,8 +702,8 @@ class TestElastic(TestCase):
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(1, count)
 
-    def test_filters_with_aggregations(self):
-        with self.app.app_context():
+    async def test_filters_with_aggregations(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_description",
                 [
@@ -727,8 +727,8 @@ class TestElastic(TestCase):
                 1, res["_aggregations"]["type"]["buckets"][0]["doc_count"]
             )
 
-    def test_filter_without_args(self):
-        with self.app.app_context():
+    async def test_filter_without_args(self):
+        async with self.app.app_context():
             self.app.data.insert("items", [{"uri": "foo"}, {"uri": "bar"}])
             req = ParsedRequest()
             cursor, count = self.app.data.find("items", req, None)
@@ -736,8 +736,8 @@ class TestElastic(TestCase):
             cursor, count = self.app.data.find("items", req, {"uri": "foo"})
             self.assertEqual(1, count)
 
-    def test_filters_with_filtered_query(self):
-        with self.app.app_context():
+    async def test_filters_with_filtered_query(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items", [{"uri": "foo"}, {"uri": "bar"}, {"uri": "baz"}]
             )
@@ -758,46 +758,46 @@ class TestElastic(TestCase):
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(0, cursor.count())
 
-    def test_basic_search_query(self):
-        with self.app.app_context():
+    async def test_basic_search_query(self):
+        async with self.app.app_context():
             self.app.data.insert("items", [{"uri": "foo"}, {"uri": "bar"}])
 
-        with self.app.test_request_context("/items/?q=foo"):
+        async with self.app.test_request_context("/items/?q=foo"):
             req = parse_request("items")
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(1, cursor.count())
 
-    def test_phrase_search_query(self):
-        with self.app.app_context():
+    async def test_phrase_search_query(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items", [{"uri": "foo bar"}, {"uri": "some text"}]
             )
 
-        with self.app.test_request_context('/items/?q="foo bar"'):
+        async with self.app.test_request_context('/items/?q="foo bar"'):
             req = parse_request("items")
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(1, cursor.count())
 
-        with self.app.test_request_context('/items/?q="bar foo"'):
+        async with self.app.test_request_context('/items/?q="bar foo"'):
             req = parse_request("items")
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(0, cursor.count())
 
-    def test_elastic_filter_callback(self):
-        with self.app.app_context():
+    async def test_elastic_filter_callback(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items_with_callback_filter", [{"uri": "foo"}, {"uri": "bar"}]
             )
 
-        with self.app.test_request_context("test?uri=foo"):
+        async with self.app.test_request_context("test?uri=foo"):
             req = parse_request("items_with_callback_filter")
             cursor, count = self.app.data.find(
                 "items_with_callback_filter", req, None
             )
             self.assertEqual(1, cursor.count())
 
-    def test_elastic_sort_by_score_if_there_is_query(self):
-        with self.app.app_context():
+    async def test_elastic_sort_by_score_if_there_is_query(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 "items",
                 [
@@ -806,28 +806,28 @@ class TestElastic(TestCase):
                 ],
             )
 
-        with self.app.test_request_context("/items/"):
+        async with self.app.test_request_context("/items/"):
             req = parse_request("items")
             req.args = {"q": "foo"}
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(2, cursor.count())
             self.assertEqual("foo", cursor[0]["uri"])
 
-    def test_elastic_find_default_sort_no_mapping(self):
-        with self.app.test_request_context("/items/"):
+    async def test_elastic_find_default_sort_no_mapping(self):
+        async with self.app.test_request_context("/items/"):
             req = parse_request("items")
             req.args = {}
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(0, cursor.count())
 
     @skip("every resource has it's own index now")
-    def test_custom_index_settings_per_resource(self):
+    async def test_custom_index_settings_per_resource(self):
         archived_index = "elastic_test_archived"
         archived_type = "archived_items"
 
         self.app.data.drop_index()
 
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.config["ELASTICSEARCH_INDEXES"] = {
                 archived_type: archived_index
             }
@@ -837,7 +837,7 @@ class TestElastic(TestCase):
 
         self.app.data = Elastic(self.app)
         self.app.data.init_app(self.app)
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.init_index()
 
         self.assertTrue(self.es.indices.exists(archived_index))
@@ -845,7 +845,7 @@ class TestElastic(TestCase):
             0, self.es.count(archived_index, archived_type)["count"]
         )
 
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.insert(
                 archived_type,
                 [{"name": "foo", "archived": "2013-01-01T11:12:13+0000"}],
@@ -855,12 +855,12 @@ class TestElastic(TestCase):
             1, self.es.count(archived_index, archived_type)["count"]
         )
 
-        with self.app.app_context():
+        async with self.app.app_context():
             item = self.app.data.find_one(archived_type, req=None, name="foo")
             self.assertEqual("foo", item["name"])
 
-    def test_no_force_refresh(self):
-        with self.app.app_context():
+    async def test_no_force_refresh(self):
+        async with self.app.app_context():
             self.app.config["ELASTICSEARCH_FORCE_REFRESH"] = False
             ids = self.app.data.insert(
                 "items",
@@ -875,8 +875,8 @@ class TestElastic(TestCase):
             cursor, count = self.app.data.find("items", req, None)
             self.assertEqual(2, cursor.count())
 
-    def test_elastic_prefix(self):
-        with self.app.app_context():
+    async def test_elastic_prefix(self):
+        async with self.app.app_context():
             mapping = self.app.data.get_mapping("items_foo")["mappings"][
                 "properties"
             ]
@@ -894,8 +894,8 @@ class TestElastic(TestCase):
             )
             self.assertEqual(2, foo_items.count())
 
-    def test_retry_on_conflict(self):
-        with self.app.app_context():
+    async def test_retry_on_conflict(self):
+        async with self.app.app_context():
             original_method = self.app.data.elastic("items").update
             update_mock = MagicMock()
             self.app.data.elastic("items").update = update_mock
@@ -923,8 +923,8 @@ class TestElastic(TestCase):
             self.assertNotIn("retry_on_conflict", update_mock.call_args[1])
             self.app.data.elastic("items").update = original_method
 
-    def test_search_multiple_resource(self):
-        with self.app.app_context():
+    async def test_search_multiple_resource(self):
+        async with self.app.app_context():
             self.app.data.insert("items", [{"uri": "foo", "name": "item"}])
             self.app.data.insert("archived_items", [{"name": "archived"}])
             self.app.data.insert("items_foo", [{"name": "foo"}])
@@ -932,8 +932,8 @@ class TestElastic(TestCase):
             docs = self.app.data.search({}, "items,archived_items")
             self.assertEqual(2, docs.count())
 
-    def test_bulk_insert_with_version(self):
-        with self.app.app_context():
+    async def test_bulk_insert_with_version(self):
+        async with self.app.app_context():
             self.app.data.bulk_insert(
                 "items",
                 [
@@ -945,8 +945,8 @@ class TestElastic(TestCase):
             item1 = self.app.data.find_one("items", req=None, _id="bar")
             self.assertIsNotNone(item1)
 
-    def test_filtered_query(self):
-        with self.app.app_context():
+    async def test_filtered_query(self):
+        async with self.app.app_context():
             self.app.data.insert("items", [{"uri": "foo", "name": "item"}])
             docs = self.app.data.search(
                 {
@@ -961,9 +961,9 @@ class TestElastic(TestCase):
             )
             self.assertEqual(1, docs.count())
 
-    def test_reindex_old_index_without_alias(self):
+    async def test_reindex_old_index_without_alias(self):
         resource = "items"
-        with self.app.app_context():
+        async with self.app.app_context():
             elastic = self.app.data
             es = elastic.elastic(resource)
             alias = elastic._resource_index(resource)
@@ -978,9 +978,9 @@ class TestElastic(TestCase):
 
             assert es.indices.exists_alias(alias)
 
-    def test_reindex_without_old_index(self):
+    async def test_reindex_without_old_index(self):
         resource = "items"
-        with self.app.app_context():
+        async with self.app.app_context():
             elastic = self.app.data
             es = elastic.elastic(resource)
             alias = elastic._resource_index(resource)
@@ -994,9 +994,9 @@ class TestElastic(TestCase):
 
             assert es.indices.exists_alias(alias)
 
-    def test_reindex(self):
+    async def test_reindex(self):
         ITEMS = "items"
-        with self.app.app_context():
+        async with self.app.app_context():
             elastic = self.app.data
             elastic.insert(ITEMS, [{"uri": "foo", "name": "item"}])
             old_index = elastic.get_index(ITEMS)
@@ -1014,10 +1014,10 @@ class TestElastic(TestCase):
             self.assertEqual(1, docs.count())
 
 
-class TestElasticSearchWithSettings(TestCase):
+class TestElasticSearchWithSettings(IsolatedAsyncioTestCase):
     resource = "items"
 
-    def setUp(self):
+    async def asyncSetUp(self):
         settings = {
             "DOMAIN": {
                 self.resource: {
@@ -1042,12 +1042,12 @@ class TestElasticSearchWithSettings(TestCase):
         }
 
         self.app = eve.Eve(settings=settings, data=Elastic)
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.init_app(self.app)
             self.app.data.init_index()
 
-    def test_elastic_settings(self):
-        with self.app.app_context():
+    async def test_elastic_settings(self):
+        async with self.app.app_context():
             settings = self.app.data.get_settings(self.resource)
             analyzer = settings["settings"]["index"]["analysis"]["analyzer"]
             self.assertDictEqual(
@@ -1059,8 +1059,8 @@ class TestElasticSearchWithSettings(TestCase):
                 analyzer["phrase_prefix_analyzer"],
             )
 
-    def test_put_settings(self):
-        with self.app.app_context():
+    async def test_put_settings(self):
+        async with self.app.app_context():
             settings = self.app.data.get_settings(self.resource)
             analyzer = settings["settings"]["index"]["analysis"]["analyzer"]
             self.assertDictEqual(
@@ -1094,8 +1094,8 @@ class TestElasticSearchWithSettings(TestCase):
                 analyzer["phrase_prefix_analyzer"],
             )
 
-    def test_put_settings_with_no_changes_existing_settings(self):
-        with self.app.app_context():
+    async def test_put_settings_with_no_changes_existing_settings(self):
+        async with self.app.app_context():
             with patch.object(
                 self.app.data.es.indices, "close", side_effect=KeyError
             ) as indices_close:
@@ -1104,8 +1104,8 @@ class TestElasticSearchWithSettings(TestCase):
                 )
             indices_close.assert_not_called()
 
-    def test_put_settings_existing_index(self):
-        with self.app.app_context():
+    async def test_put_settings_existing_index(self):
+        async with self.app.app_context():
             self.app.config["DOMAIN"] = deepcopy(self.app.config["DOMAIN"])
             self.app.config["DOMAIN"]["items"]["schema"]["slugline"] = {
                 "type": "string",
@@ -1143,7 +1143,7 @@ class TestElasticSearchWithSettings(TestCase):
 
 
 @skip("no parent/child join between indexes")
-class TestElasticSearchParentChild(TestCase):
+class TestElasticSearchParentChild(IsolatedAsyncioTestCase):
     index_name = "elastic_index"
     parent_item = "items"
     child_item = "child_items"
@@ -1170,7 +1170,7 @@ class TestElasticSearchParentChild(TestCase):
         },
     }
 
-    def setUp(self):
+    async def asyncSetUp(self):
         settings = {
             "DOMAIN": self.domain,
             "ELASTICSEARCH_URL": "http://localhost:9200",
@@ -1179,7 +1179,7 @@ class TestElasticSearchParentChild(TestCase):
         }
 
         self.app = eve.Eve(settings=settings, data=Elastic)
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.init_index()
             for resource in self.app.config["DOMAIN"]:
                 self.app.data.remove(resource)
@@ -1187,15 +1187,15 @@ class TestElasticSearchParentChild(TestCase):
             self.es = get_es(self.app.config.get("ELASTICSEARCH_URL"))
             self.checkVersion()
 
-    def checkVersion(self):
-        with self.app.app_context():
+    async def checkVersion(self):
+        async with self.app.app_context():
             info = self.es.info()
             self.version_2x = (
                 info.get("version", {}).get("number", "").startswith("2")
             )
 
-    def test_child_items_mapping(self):
-        with self.app.app_context():
+    async def test_child_items_mapping(self):
+        async with self.app.app_context():
             mapping = self.es.indices.get_mapping(
                 index=self.index_name, doc_type="child_items"
             )
@@ -1210,8 +1210,8 @@ class TestElasticSearchParentChild(TestCase):
                     {"required": True},
                 )
 
-    def test_insert_child_item(self):
-        with self.app.app_context():
+    async def test_insert_child_item(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 self.parent_item,
                 [{"_id": "foo", "name": "foo", "headline": "test"}],
@@ -1248,8 +1248,8 @@ class TestElasticSearchParentChild(TestCase):
             self.assertEqual(child["name"], "childfoo")
             self.assertEqual(child["item_id"], "foo")
 
-    def test_insert_child_item_with_no_parent(self):
-        with self.app.app_context():
+    async def test_insert_child_item_with_no_parent(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 self.child_item,
                 [
@@ -1269,8 +1269,8 @@ class TestElasticSearchParentChild(TestCase):
             self.assertEqual(child["name"], "childfoo")
             self.assertEqual(child["item_id"], "test")
 
-    def test_update_child_item(self):
-        with self.app.app_context():
+    async def test_update_child_item(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 self.parent_item,
                 [{"_id": "foo", "name": "foo", "headline": "test"}],
@@ -1315,8 +1315,8 @@ class TestElasticSearchParentChild(TestCase):
             self.assertEqual(child["item_id"], "foo")
             self.assertEqual(child["headline"], "test test")
 
-    def test_update_child_item_with_no_parent_raises_exception(self):
-        with self.app.app_context():
+    async def test_update_child_item_with_no_parent_raises_exception(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 self.parent_item,
                 [{"_id": "foo", "name": "foo", "headline": "test"}],
@@ -1352,8 +1352,8 @@ class TestElasticSearchParentChild(TestCase):
             else:
                 self.assertIn("RoutingMissingException", cm.exception.error)
 
-    def test_update_child_item_and_change_parent_raises_exception(self):
-        with self.app.app_context():
+    async def test_update_child_item_and_change_parent_raises_exception(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 self.parent_item,
                 [{"_id": "foo", "name": "foo", "headline": "test"}],
@@ -1390,8 +1390,8 @@ class TestElasticSearchParentChild(TestCase):
             else:
                 self.assertIn("DocumentMissingException", cm.exception.error)
 
-    def test_bulk_insert_child_items(self):
-        with self.app.app_context():
+    async def test_bulk_insert_child_items(self):
+        async with self.app.app_context():
             (count, _errors) = self.app.data.bulk_insert(
                 self.child_item,
                 [
@@ -1403,8 +1403,8 @@ class TestElasticSearchParentChild(TestCase):
             self.assertEqual(3, count)
             self.assertEqual(0, len(_errors))
 
-    def test_replace_child_item(self):
-        with self.app.app_context():
+    async def test_replace_child_item(self):
+        async with self.app.app_context():
             res = self.app.data.insert(
                 self.child_item,
                 [{"_id": "foo", "name": "testing", "item_id": "test"}],
@@ -1414,8 +1414,8 @@ class TestElasticSearchParentChild(TestCase):
             res = self.app.data.replace(self.child_item, "foo", new_item)
             self.assertEqual(2, res["_version"])
 
-    def test_replace_child_item_with_no_parent_raises_exception(self):
-        with self.app.app_context():
+    async def test_replace_child_item_with_no_parent_raises_exception(self):
+        async with self.app.app_context():
             res = self.app.data.insert(
                 self.child_item,
                 [{"_id": "foo", "name": "testing", "item_id": "test"}],
@@ -1433,8 +1433,8 @@ class TestElasticSearchParentChild(TestCase):
             else:
                 self.assertIn("RoutingMissingException", cm.exception.error)
 
-    def test_parent_child_query(self):
-        with self.app.app_context():
+    async def test_parent_child_query(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 self.parent_item,
                 [
@@ -1479,8 +1479,8 @@ class TestElasticSearchParentChild(TestCase):
             self.assertEqual(results[0].get("_id"), "foo")
             self.assertEqual(results[0].get("_type"), self.parent_item)
 
-    def test_remove_child(self):
-        with self.app.app_context():
+    async def test_remove_child(self):
+        async with self.app.app_context():
             self.app.data.insert(
                 self.parent_item,
                 [{"_id": "foo", "name": "foo", "headline": "test"}],
@@ -1503,7 +1503,7 @@ class TestElasticSearchParentChild(TestCase):
             self.assertIsNone(child)
 
 
-class TestElasticInnerHits(TestCase):
+class TestElasticInnerHits(IsolatedAsyncioTestCase):
     index_name = "elastic_innerhits"
     data = [
         {
@@ -1540,7 +1540,7 @@ class TestElasticInnerHits(TestCase):
         }
     }
 
-    def setUp(self):
+    async def asyncSetUp(self):
         settings = {
             "DOMAIN": self.domain,
             "ELASTICSEARCH_URL": "http://localhost:9200",
@@ -1549,13 +1549,13 @@ class TestElasticInnerHits(TestCase):
         }
 
         self.app = eve.Eve(settings=settings, data=Elastic)
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.drop_index()
             self.app.data.init_index()
             self.es = get_es(self.app.config.get("ELASTICSEARCH_URL"))
 
-    def test_inner_hits_query(self):
-        with self.app.app_context():
+    async def test_inner_hits_query(self):
+        async with self.app.app_context():
             self.app.data.insert("items", self.data)
             query = {
                 "query": {
@@ -1593,7 +1593,7 @@ class TestElasticInnerHits(TestCase):
             )
 
 
-class TestElasticNested(TestCase):
+class TestElasticNested(IsolatedAsyncioTestCase):
     index_name = "elastic_nested"
     data = [
         {
@@ -1635,7 +1635,7 @@ class TestElasticNested(TestCase):
         }
     }
 
-    def setUp(self):
+    async def asyncSetUp(self):
         settings = {
             "DOMAIN": self.domain,
             "ELASTICSEARCH_URL": "http://localhost:9200",
@@ -1644,13 +1644,13 @@ class TestElasticNested(TestCase):
         }
 
         self.app = eve.Eve(settings=settings, data=Elastic)
-        with self.app.app_context():
+        async with self.app.app_context():
             self.app.data.drop_index()
             self.app.data.init_index()
             self.es = get_es(self.app.config.get("ELASTICSEARCH_URL"))
 
-    def test_nested_sort(self):
-        with self.app.app_context():
+    async def test_nested_sort(self):
+        async with self.app.app_context():
             self.app.data.insert("items", self.data)
             query = {
                 "query": {


### PR DESCRIPTION
### Purpose
Make some of the code in this library more easily used by a class that inherits from it (mainly the find kwargs)
Fix tests, after switching to Quart - using async in tests.

**Note:** Placing the async elastic datalayer in Superdesk, as it requires our datalayer to handle async requests through app.data